### PR TITLE
[FEDEXSHIP-34] allows for multiple items to be packed into multiple boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added new endpoint for multiple items packing for multiple boxes
+
 ## [0.3.0] - 2022-05-05
 
 ### Added

--- a/dotnet/Controllers/RoutesController.cs
+++ b/dotnet/Controllers/RoutesController.cs
@@ -10,6 +10,7 @@
     using Newtonsoft.Json;
     using PackingOptimization.Models;
     using PackingOptimization.Data;
+    using PackingOptimization.Services;
     using CromulentBisgetti.ContainerPacking;
     using CromulentBisgetti.ContainerPacking.Entities;
     using CromulentBisgetti.ContainerPacking.Algorithms;
@@ -64,6 +65,23 @@
             }
 
             return Json(resultList);
+        }
+
+        public async Task<IActionResult> packAll()
+        {
+            this._merchantSettings = await _merchantSettingsRepository.GetMerchantSettings();
+
+            List<Container> containerList = new List<Container>();
+            foreach (ContainerObject container in this._merchantSettings.ContainerList) {
+                containerList.Add(new Container(container.Id, container.Length, container.Width, container.Height));
+            }
+
+            var bodyAsText = await new System.IO.StreamReader(HttpContext.Request.Body).ReadToEndAsync();
+            BasicContainerPackingRequest packingRequest = JsonConvert.DeserializeObject<BasicContainerPackingRequest>(bodyAsText);
+
+            List<ContainerPackingResult> multiboxPack = MultiboxPackService.multiboxPack(packingRequest, containerList);
+
+            return Json(multiboxPack);
         }
     }
 }

--- a/dotnet/Services/MultiboxPackService.cs
+++ b/dotnet/Services/MultiboxPackService.cs
@@ -1,0 +1,69 @@
+using PackingOptimization.Models;
+using System.Collections.Generic;
+using System;
+using Newtonsoft.Json;
+using CromulentBisgetti.ContainerPacking;
+using CromulentBisgetti.ContainerPacking.Entities;
+using CromulentBisgetti.ContainerPacking.Algorithms;
+
+namespace PackingOptimization.Services
+{
+    public class MultiboxPackService
+    {
+        public static List<ContainerPackingResult> multiboxPack(BasicContainerPackingRequest packingRequest, List<Container> containerList)
+        {
+            List<int> algoTypeID = new List<int>();
+            algoTypeID.Add(1);
+            
+            List<ContainerPackingResult> packResult = recursivePack(containerList, packingRequest.ItemsToPack, algoTypeID, new List<ContainerPackingResult>());
+
+            return packResult;
+        }
+
+        private static List<ContainerPackingResult> recursivePack(List<Container> containerList, List<Item> itemsToPack, List<int> algoTypeID, List<ContainerPackingResult> results)
+        {
+            // Base Case
+            if (itemsToPack.Capacity == 0)
+            {
+                return results;
+            }
+
+            List<ContainerPackingResult> packResult = PackingService.Pack(containerList, itemsToPack, algoTypeID);
+
+            decimal maxItemVolPacked = -1;
+            ContainerPackingResult previousContainerPointer = new ContainerPackingResult();
+
+            // Finds max value of PercentItemVolumePacked and PercentContainerVolumePacked
+            foreach (ContainerPackingResult iterPackResult in packResult)
+            {
+                // If more item packed, set previous pointer to current container
+                if (iterPackResult.AlgorithmPackingResults[0].PercentItemVolumePacked > maxItemVolPacked)
+                {
+                    maxItemVolPacked = iterPackResult.AlgorithmPackingResults[0].PercentItemVolumePacked;
+                    previousContainerPointer = iterPackResult;
+                }
+                // If equal volume item packed, set pointer to greater container volume packed
+                // Greater container volume packed and equal volume item packed means that the box is smaller
+                else if (
+                    iterPackResult.AlgorithmPackingResults[0].PercentItemVolumePacked == maxItemVolPacked &&
+                    iterPackResult.AlgorithmPackingResults[0].PercentContainerVolumePacked > previousContainerPointer.AlgorithmPackingResults[0].PercentContainerVolumePacked
+                )
+                {
+                    previousContainerPointer = iterPackResult;
+                }
+            }
+
+            // No boxes can fit this item
+            // Prevent stack overflow
+            if (previousContainerPointer.AlgorithmPackingResults[0].PackedItems.Capacity == 0)
+            {
+                return results;
+            }
+
+            results.Add(previousContainerPointer);
+
+            // Recursively pack the remainder items
+            return recursivePack(containerList, previousContainerPointer.AlgorithmPackingResults[0].UnpackedItems, algoTypeID, results);
+        }
+    }
+}

--- a/dotnet/service.json
+++ b/dotnet/service.json
@@ -3,8 +3,7 @@
   "memory": 256,
   "timeout": 30,
   "ttl": 30,
-  "runtimeArgs": [
-  ],
+  "runtimeArgs": [],
   "routes": {
     "pack": {
       "path": "/pack",
@@ -18,6 +17,16 @@
     },
     "multiPack": {
       "path": "/multiPack",
+      "public": false,
+      "policies": [
+        {
+          "effect": "allow",
+          "actions": ["post"]
+        }
+      ]
+    },
+    "packAll": {
+      "path": "/packAll",
       "public": false,
       "policies": [
         {


### PR DESCRIPTION
Changes
- Pack multiple items into multiple boxess

POST
https://app.io.vtex.com/vtex.packing-optimization/v0/sandboxusdev/fedex/packAll

Sample Request
```json
{
    "ItemsToPack": [
        {
            "ID": 1,
            "Dim1": 1,
            "Dim2": 1,
            "Dim3": 1,
            "Quantity": 2
        },
        {
            "ID": 2,
            "Dim1": 1,
            "Dim2": 2,
            "Dim3": 2,
            "Quantity": 1
        },
        {
            "ID": 3,
            "Dim1": 1,
            "Dim2": 2,
            "Dim3": 3,
            "Quantity": 1
        },
        {
            "ID": 4,
            "Dim1": 1,
            "Dim2": 2,
            "Dim3": 3,
            "Quantity": 1
        },
        {
            "ID": 5,
            "Dim1": 100,
            "Dim2": 2,
            "Dim3": 3,
            "Quantity": 1
        }
    ]
}
```
